### PR TITLE
Load streamed coke props

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -45,7 +45,11 @@ Config.Controls = {
 Config.Placeables = {
     coke2 = {
         label = 'Paquet de coke',
-        models = { 'prop_tool_blowtorch' },
+        models = {
+            'prop_bzzz_drugs_coke001',
+            'prop_bzzz_drugs_coke002',
+            'prop_bzzz_drugs_coke003'
+        },
         icon = 'fa-solid fa-box',
         interactDistance = 2.0,
         pickupLabel = 'Ramasser le paquet',

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -7,6 +7,13 @@ author 'Outlaw — placeables without DB'
 version '1.2.2'
 description 'Camera-centered preview with pure camera-ray scrolling (no ped clamp), snap-to-ground.'
 
+files {
+    'stream/*.ytyp',
+    'stream/*.ydr'
+}
+
+data_file 'DLC_ITYP_REQUEST' 'stream/prop_bzzz_drugs_coke.ytyp'
+
 shared_scripts {
     'config.lua',
     'NativeProps/*.lua'


### PR DESCRIPTION
## Summary
- register streamed coke models in the manifest so they are requested at runtime
- configure the coke2 placeable item to use the streamed prop models instead of a native placeholder

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5798ce9cc83288c2147c5ee929d4c